### PR TITLE
fix: Add missing major and latest tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,5 @@
 test:
 	node --test test/**/*.test.js
 
+test-watch:
+	node --watch --test test/**/*.test.js

--- a/test/prepare-matrix.test.js
+++ b/test/prepare-matrix.test.js
@@ -21,10 +21,10 @@ test("images contains all known images and variants", () => {
       variants: [
         {
           name: "alpine",
-          latest: true,
         },
         {
           name: "bookworm",
+          latest: true,
         },
       ],
     },
@@ -80,6 +80,7 @@ test("images contains all known images and variants", () => {
         },
         {
           name: "node-24",
+          latest: true,
           subvariants: [
             {
               name: "ruby-3",
@@ -119,6 +120,7 @@ test("images contains all known images and variants", () => {
       variants: [
         {
           name: "alpine",
+          latest: true,
         },
       ],
     },
@@ -127,6 +129,7 @@ test("images contains all known images and variants", () => {
       variants: [
         {
           name: "alpine",
+          latest: true,
         },
       ],
     },
@@ -165,7 +168,7 @@ test("generateMatrix includes all variants of curl", () => {
       id: "curl-alpine",
       image: "curl",
       context: "images/curl/alpine",
-      tags: "kula/curl:alpine",
+      tags: ["kula/curl:alpine", "kula/curl:latest"].join("\n"),
     },
     `matrix should include curl, found: ${entries[0].tags}`
   );
@@ -191,7 +194,7 @@ test("generateMatrix includes all variants of jq", () => {
       id: "jq-bookworm",
       image: "jq",
       context: "images/jq/bookworm",
-      tags: "kula/jq:bookworm",
+      tags: ["kula/jq:bookworm", "kula/jq:latest"].join("\n"),
     },
     `matrix should include jq, found: ${entries[1].tags}`
   );
@@ -217,7 +220,7 @@ test("generateMatrix includes all variants of lftp", () => {
       id: "lftp-bookworm",
       image: "lftp",
       context: "images/lftp/bookworm",
-      tags: "kula/lftp:bookworm",
+      tags: ["kula/lftp:bookworm", "kula/lftp:latest"].join("\n"),
     },
     `matrix should include lftp, found: ${entries[1].tags}`
   );
@@ -258,12 +261,14 @@ test("generateMatrix includes all variants of node-rbenv", () => {
       image: "node-rbenv",
       context: "images/node-rbenv/node-20/ruby-3",
       tags: [
-        "kula/node-rbenv:20.19",
+        "kula/node-rbenv:20-ruby3",
+        "kula/node-rbenv:20-ruby3.4",
+        "kula/node-rbenv:20-ruby3.4.5",
         "kula/node-rbenv:20.19-ruby3",
-        "kula/node-rbenv:20.19.5-ruby3",
         "kula/node-rbenv:20.19-ruby3.4",
-        "kula/node-rbenv:20.19.5-ruby3.4",
         "kula/node-rbenv:20.19-ruby3.4.5",
+        "kula/node-rbenv:20.19.5-ruby3",
+        "kula/node-rbenv:20.19.5-ruby3.4",
         "kula/node-rbenv:20.19.5-ruby3.4.5",
       ].join("\n"),
     },
@@ -276,9 +281,9 @@ test("generateMatrix includes all variants of node-rbenv", () => {
       image: "node-rbenv",
       context: "images/node-rbenv/node-20-slim",
       tags: [
-        "kula/node-rbenv:20",
-        "kula/node-rbenv:20.19",
-        "kula/node-rbenv:20.19.5",
+        "kula/node-rbenv:20-slim",
+        "kula/node-rbenv:20.19-slim",
+        "kula/node-rbenv:20.19.5-slim",
       ].join("\n"),
     },
     `matrix should include node-rbenv, found: ${entries[2].tags}`
@@ -290,13 +295,15 @@ test("generateMatrix includes all variants of node-rbenv", () => {
       image: "node-rbenv",
       context: "images/node-rbenv/node-20-slim/ruby-3",
       tags: [
-        "kula/node-rbenv:20.19",
-        "kula/node-rbenv:20.19-ruby3",
-        "kula/node-rbenv:20.19.5-ruby3",
-        "kula/node-rbenv:20.19-ruby3.4",
-        "kula/node-rbenv:20.19.5-ruby3.4",
-        "kula/node-rbenv:20.19-ruby3.4.5",
-        "kula/node-rbenv:20.19.5-ruby3.4.5",
+        "kula/node-rbenv:20-slim-ruby3",
+        "kula/node-rbenv:20-slim-ruby3.4",
+        "kula/node-rbenv:20-slim-ruby3.4.5",
+        "kula/node-rbenv:20.19-slim-ruby3",
+        "kula/node-rbenv:20.19-slim-ruby3.4",
+        "kula/node-rbenv:20.19-slim-ruby3.4.5",
+        "kula/node-rbenv:20.19.5-slim-ruby3",
+        "kula/node-rbenv:20.19.5-slim-ruby3.4",
+        "kula/node-rbenv:20.19.5-slim-ruby3.4.5",
       ].join("\n"),
     },
     `matrix should include node-rbenv, found: ${entries[3].tags}`
@@ -322,12 +329,14 @@ test("generateMatrix includes all variants of node-rbenv", () => {
       image: "node-rbenv",
       context: "images/node-rbenv/node-22/ruby-3",
       tags: [
-        "kula/node-rbenv:22.20",
+        "kula/node-rbenv:22-ruby3",
+        "kula/node-rbenv:22-ruby3.4",
+        "kula/node-rbenv:22-ruby3.4.5",
         "kula/node-rbenv:22.20-ruby3",
-        "kula/node-rbenv:22.20.0-ruby3",
         "kula/node-rbenv:22.20-ruby3.4",
-        "kula/node-rbenv:22.20.0-ruby3.4",
         "kula/node-rbenv:22.20-ruby3.4.5",
+        "kula/node-rbenv:22.20.0-ruby3",
+        "kula/node-rbenv:22.20.0-ruby3.4",
         "kula/node-rbenv:22.20.0-ruby3.4.5",
       ].join("\n"),
     },
@@ -340,9 +349,9 @@ test("generateMatrix includes all variants of node-rbenv", () => {
       image: "node-rbenv",
       context: "images/node-rbenv/node-22-slim",
       tags: [
-        "kula/node-rbenv:22",
-        "kula/node-rbenv:22.20",
-        "kula/node-rbenv:22.20.0",
+        "kula/node-rbenv:22-slim",
+        "kula/node-rbenv:22.20-slim",
+        "kula/node-rbenv:22.20.0-slim",
       ].join("\n"),
     },
     `matrix should include node-rbenv, found: ${entries[6].tags}`
@@ -354,13 +363,15 @@ test("generateMatrix includes all variants of node-rbenv", () => {
       image: "node-rbenv",
       context: "images/node-rbenv/node-22-slim/ruby-3",
       tags: [
-        "kula/node-rbenv:22.20",
-        "kula/node-rbenv:22.20-ruby3",
-        "kula/node-rbenv:22.20.0-ruby3",
-        "kula/node-rbenv:22.20-ruby3.4",
-        "kula/node-rbenv:22.20.0-ruby3.4",
-        "kula/node-rbenv:22.20-ruby3.4.5",
-        "kula/node-rbenv:22.20.0-ruby3.4.5",
+        "kula/node-rbenv:22-slim-ruby3",
+        "kula/node-rbenv:22-slim-ruby3.4",
+        "kula/node-rbenv:22-slim-ruby3.4.5",
+        "kula/node-rbenv:22.20-slim-ruby3",
+        "kula/node-rbenv:22.20-slim-ruby3.4",
+        "kula/node-rbenv:22.20-slim-ruby3.4.5",
+        "kula/node-rbenv:22.20.0-slim-ruby3",
+        "kula/node-rbenv:22.20.0-slim-ruby3.4",
+        "kula/node-rbenv:22.20.0-slim-ruby3.4.5",
       ].join("\n"),
     },
     `matrix should include node-rbenv, found: ${entries[7].tags}`
@@ -375,6 +386,7 @@ test("generateMatrix includes all variants of node-rbenv", () => {
         "kula/node-rbenv:24",
         "kula/node-rbenv:24.9",
         "kula/node-rbenv:24.9.0",
+        "kula/node-rbenv:latest",
       ].join("\n"),
     },
     `matrix should include node-rbenv, found: ${entries[8].tags}`
@@ -386,12 +398,14 @@ test("generateMatrix includes all variants of node-rbenv", () => {
       image: "node-rbenv",
       context: "images/node-rbenv/node-24/ruby-3",
       tags: [
-        "kula/node-rbenv:24.9",
+        "kula/node-rbenv:24-ruby3",
+        "kula/node-rbenv:24-ruby3.4",
+        "kula/node-rbenv:24-ruby3.4.5",
         "kula/node-rbenv:24.9-ruby3",
-        "kula/node-rbenv:24.9.0-ruby3",
         "kula/node-rbenv:24.9-ruby3.4",
-        "kula/node-rbenv:24.9.0-ruby3.4",
         "kula/node-rbenv:24.9-ruby3.4.5",
+        "kula/node-rbenv:24.9.0-ruby3",
+        "kula/node-rbenv:24.9.0-ruby3.4",
         "kula/node-rbenv:24.9.0-ruby3.4.5",
       ].join("\n"),
     },
@@ -404,9 +418,9 @@ test("generateMatrix includes all variants of node-rbenv", () => {
       image: "node-rbenv",
       context: "images/node-rbenv/node-24-slim",
       tags: [
-        "kula/node-rbenv:24",
-        "kula/node-rbenv:24.9",
-        "kula/node-rbenv:24.9.0",
+        "kula/node-rbenv:24-slim",
+        "kula/node-rbenv:24.9-slim",
+        "kula/node-rbenv:24.9.0-slim",
       ].join("\n"),
     },
     `matrix should include node-rbenv, found: ${entries[10].tags}`
@@ -418,13 +432,15 @@ test("generateMatrix includes all variants of node-rbenv", () => {
       image: "node-rbenv",
       context: "images/node-rbenv/node-24-slim/ruby-3",
       tags: [
-        "kula/node-rbenv:24.9",
-        "kula/node-rbenv:24.9-ruby3",
-        "kula/node-rbenv:24.9.0-ruby3",
-        "kula/node-rbenv:24.9-ruby3.4",
-        "kula/node-rbenv:24.9.0-ruby3.4",
-        "kula/node-rbenv:24.9-ruby3.4.5",
-        "kula/node-rbenv:24.9.0-ruby3.4.5",
+        "kula/node-rbenv:24-slim-ruby3",
+        "kula/node-rbenv:24-slim-ruby3.4",
+        "kula/node-rbenv:24-slim-ruby3.4.5",
+        "kula/node-rbenv:24.9-slim-ruby3",
+        "kula/node-rbenv:24.9-slim-ruby3.4",
+        "kula/node-rbenv:24.9-slim-ruby3.4.5",
+        "kula/node-rbenv:24.9.0-slim-ruby3",
+        "kula/node-rbenv:24.9.0-slim-ruby3.4",
+        "kula/node-rbenv:24.9.0-slim-ruby3.4.5",
       ].join("\n"),
     },
     `matrix should include node-rbenv, found: ${entries[11].tags}`
@@ -461,7 +477,9 @@ test("generateMatrix includes all variants of pulumi-toolbox", () => {
       id: "pulumi-toolbox-bookworm",
       image: "pulumi-toolbox",
       context: "images/pulumi-toolbox/bookworm",
-      tags: "kula/pulumi-toolbox:bookworm",
+      tags: ["kula/pulumi-toolbox:bookworm", "kula/pulumi-toolbox:latest"].join(
+        "\n"
+      ),
     },
     `matrix should include pulumi-toolbox, found: ${entries[1].tags}`
   );
@@ -485,7 +503,7 @@ test("generateMatrix includes all variants of rsync", () => {
     id: "rsync-alpine",
     image: "rsync",
     context: "images/rsync/alpine",
-    tags: "kula/rsync:alpine",
+    tags: ["kula/rsync:alpine", "kula/rsync:latest"].join("\n"),
   });
   assert.equal(entries.length, 1);
 });
@@ -497,6 +515,7 @@ test("generateMatrix includes all variants of tree", () => {
     id: "tree-alpine",
     image: "tree",
     context: "images/tree/alpine",
-    tags: "kula/tree:alpine",
+    tags: ["kula/tree:alpine", "kula/tree:latest"].join("\n"),
   });
+  assert.equal(entries.length, 1);
 });


### PR DESCRIPTION
This pull request updates the test suite for Docker image matrix generation, focusing on improving tag coverage and accuracy for various image variants. The main changes ensure that the latest tags are consistently included and that the tag naming conventions better reflect the image and variant structure.

**Tag coverage and naming improvements:**

* Added the `latest` property to several image variants in test cases to ensure that the latest tag is tracked and tested for each relevant variant. [[1]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deL24-R27) [[2]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deR83) [[3]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deR123) [[4]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deR132)
* Updated tag arrays for images like `curl`, `jq`, `lftp`, `pulumi-toolbox`, `rsync`, and `tree` to include both the specific variant tag and the corresponding `latest` tag, improving test coverage for tag generation logic. [[1]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deL168-R171) [[2]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deL194-R197) [[3]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deL220-R223) [[4]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deL464-R482) [[5]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deL488-R506) [[6]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deL500-R520)

**Node-rbenv image matrix enhancements:**

* Refactored tag generation for `node-rbenv` variants to use a more consistent pattern (e.g., `20-ruby3` instead of `20.19-ruby3`), added missing tags for sub-variants, and ensured all possible combinations are covered in the tests. [[1]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deL261-R271) [[2]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deL279-R286) [[3]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deL293-R306) [[4]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deL325-R339) [[5]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deL343-R354) [[6]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deL357-R374) [[7]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deR389) [[8]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deL389-R408) [[9]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deL407-R423) [[10]](diffhunk://#diff-574c0c7ce0c303d4b176580d714493f7a6aff98d2371dde1e37181be772834deL421-R443)

**Testing workflow improvement:**

* Added a `test-watch` target to the `Makefile` to allow running tests in watch mode for faster feedback during development.