### PR TITLE
refactor: Inline node-rbenv Dockerfile into node-rbenv/ruby images

### DIFF
--- a/images/node-rbenv/node-20-slim/ruby-3/Dockerfile
+++ b/images/node-rbenv/node-20-slim/ruby-3/Dockerfile
@@ -9,12 +9,48 @@ ARG RUBY_VERSION=3.4.5
 
 # ====================================================== PRODUCT =======================================================
 
-FROM kula/node-rbenv:${NODE_VERSION}-slim
+FROM node:${NODE_VERSION}-slim
 ARG RUBY_VERSION
 
 # Metadata
 LABEL maintainer="kula app GmbH <opensource@kula.app>"
 LABEL description="Container with rbenv and node 20 slim with ruby 3"
+
+# Update dependencies
+RUN apt-get update -qq >/dev/null && apt-get upgrade -y --no-install-recommends
+RUN apt-get install -y \
+  autoconf \
+  bison \
+  build-essential \
+  curl \
+  git \
+  libdb-dev \
+  libffi-dev \
+  libgdbm-dev \
+  libgdbm6 \
+  libncurses5-dev \
+  libreadline6-dev \
+  libssl-dev \
+  libyaml-dev \
+  uuid-dev \
+  zlib1g-dev && \
+  rm -rf /var/lib/apt/lists/*
+
+# Install rbenv
+RUN git clone https://github.com/sstephenson/rbenv.git /usr/local/rbenv
+RUN echo '# rbenv setup' >/etc/profile.d/rbenv.sh
+RUN echo 'export RBENV_ROOT=/usr/local/rbenv' >>/etc/profile.d/rbenv.sh
+RUN echo 'export PATH="$RBENV_ROOT/bin:$PATH"' >>/etc/profile.d/rbenv.sh
+RUN echo 'eval "$(rbenv init -)"' >>/etc/profile.d/rbenv.sh
+RUN chmod +x /etc/profile.d/rbenv.sh
+
+# Install ruby-build
+RUN mkdir /usr/local/rbenv/plugins
+RUN git clone https://github.com/sstephenson/ruby-build.git /usr/local/rbenv/plugins/ruby-build
+
+# Setup rbenv shimming
+ENV RBENV_ROOT=/usr/local/rbenv
+ENV PATH=$RBENV_ROOT/bin:$RBENV_ROOT/shims:$PATH
 
 # Install ruby versions
 RUN rbenv install ${RUBY_VERSION} && rbenv global ${RUBY_VERSION}

--- a/images/node-rbenv/node-20/ruby-3/Dockerfile
+++ b/images/node-rbenv/node-20/ruby-3/Dockerfile
@@ -9,12 +9,48 @@ ARG RUBY_VERSION=3.4.5
 
 # ====================================================== PRODUCT =======================================================
 
-FROM kula/node-rbenv:${NODE_VERSION}
+FROM node:${NODE_VERSION}
 ARG RUBY_VERSION
 
 # Metadata
 LABEL maintainer="kula app GmbH <opensource@kula.app>"
 LABEL description="Container with rbenv and node 20 with ruby 3"
+
+# Update dependencies
+RUN apt-get update -qq >/dev/null && apt-get upgrade -y --no-install-recommends
+RUN apt-get install -y \
+  autoconf \
+  bison \
+  build-essential \
+  curl \
+  git \
+  libdb-dev \
+  libffi-dev \
+  libgdbm-dev \
+  libgdbm6 \
+  libncurses5-dev \
+  libreadline6-dev \
+  libssl-dev \
+  libyaml-dev \
+  uuid-dev \
+  zlib1g-dev && \
+  rm -rf /var/lib/apt/lists/*
+
+# Install rbenv
+RUN git clone https://github.com/sstephenson/rbenv.git /usr/local/rbenv
+RUN echo '# rbenv setup' >/etc/profile.d/rbenv.sh
+RUN echo 'export RBENV_ROOT=/usr/local/rbenv' >>/etc/profile.d/rbenv.sh
+RUN echo 'export PATH="$RBENV_ROOT/bin:$PATH"' >>/etc/profile.d/rbenv.sh
+RUN echo 'eval "$(rbenv init -)"' >>/etc/profile.d/rbenv.sh
+RUN chmod +x /etc/profile.d/rbenv.sh
+
+# Install ruby-build
+RUN mkdir /usr/local/rbenv/plugins
+RUN git clone https://github.com/sstephenson/ruby-build.git /usr/local/rbenv/plugins/ruby-build
+
+# Setup rbenv shimming
+ENV RBENV_ROOT=/usr/local/rbenv
+ENV PATH=$RBENV_ROOT/bin:$RBENV_ROOT/shims:$PATH
 
 # Install ruby versions
 RUN rbenv install ${RUBY_VERSION} && rbenv global ${RUBY_VERSION}

--- a/images/node-rbenv/node-22-slim/ruby-3/Dockerfile
+++ b/images/node-rbenv/node-22-slim/ruby-3/Dockerfile
@@ -9,12 +9,48 @@ ARG RUBY_VERSION=3.4.5
 
 # ====================================================== PRODUCT =======================================================
 
-FROM kula/node-rbenv:${NODE_VERSION}-slim
+FROM node:${NODE_VERSION}-slim
 ARG RUBY_VERSION
 
 # Metadata
 LABEL maintainer="kula app GmbH <opensource@kula.app>"
 LABEL description="Container with rbenv and node 22 slim with ruby 3"
+
+# Update dependencies
+RUN apt-get update -qq >/dev/null && apt-get upgrade -y --no-install-recommends
+RUN apt-get install -y \
+  autoconf \
+  bison \
+  build-essential \
+  curl \
+  git \
+  libdb-dev \
+  libffi-dev \
+  libgdbm-dev \
+  libgdbm6 \
+  libncurses5-dev \
+  libreadline6-dev \
+  libssl-dev \
+  libyaml-dev \
+  uuid-dev \
+  zlib1g-dev && \
+  rm -rf /var/lib/apt/lists/*
+
+# Install rbenv
+RUN git clone https://github.com/sstephenson/rbenv.git /usr/local/rbenv
+RUN echo '# rbenv setup' >/etc/profile.d/rbenv.sh
+RUN echo 'export RBENV_ROOT=/usr/local/rbenv' >>/etc/profile.d/rbenv.sh
+RUN echo 'export PATH="$RBENV_ROOT/bin:$PATH"' >>/etc/profile.d/rbenv.sh
+RUN echo 'eval "$(rbenv init -)"' >>/etc/profile.d/rbenv.sh
+RUN chmod +x /etc/profile.d/rbenv.sh
+
+# Install ruby-build
+RUN mkdir /usr/local/rbenv/plugins
+RUN git clone https://github.com/sstephenson/ruby-build.git /usr/local/rbenv/plugins/ruby-build
+
+# Setup rbenv shimming
+ENV RBENV_ROOT=/usr/local/rbenv
+ENV PATH=$RBENV_ROOT/bin:$RBENV_ROOT/shims:$PATH
 
 # Install ruby versions
 RUN rbenv install ${RUBY_VERSION} && rbenv global ${RUBY_VERSION}

--- a/images/node-rbenv/node-22/ruby-3/Dockerfile
+++ b/images/node-rbenv/node-22/ruby-3/Dockerfile
@@ -9,12 +9,48 @@ ARG RUBY_VERSION=3.4.5
 
 # ====================================================== PRODUCT =======================================================
 
-FROM kula/node-rbenv:${NODE_VERSION}
+FROM node:${NODE_VERSION}
 ARG RUBY_VERSION
 
 # Metadata
 LABEL maintainer="kula app GmbH <opensource@kula.app>"
 LABEL description="Container with rbenv and node 22 with ruby 3"
+
+# Update dependencies
+RUN apt-get update -qq >/dev/null && apt-get upgrade -y --no-install-recommends
+RUN apt-get install -y \
+  autoconf \
+  bison \
+  build-essential \
+  curl \
+  git \
+  libdb-dev \
+  libffi-dev \
+  libgdbm-dev \
+  libgdbm6 \
+  libncurses5-dev \
+  libreadline6-dev \
+  libssl-dev \
+  libyaml-dev \
+  uuid-dev \
+  zlib1g-dev && \
+  rm -rf /var/lib/apt/lists/*
+
+# Install rbenv
+RUN git clone https://github.com/sstephenson/rbenv.git /usr/local/rbenv
+RUN echo '# rbenv setup' >/etc/profile.d/rbenv.sh
+RUN echo 'export RBENV_ROOT=/usr/local/rbenv' >>/etc/profile.d/rbenv.sh
+RUN echo 'export PATH="$RBENV_ROOT/bin:$PATH"' >>/etc/profile.d/rbenv.sh
+RUN echo 'eval "$(rbenv init -)"' >>/etc/profile.d/rbenv.sh
+RUN chmod +x /etc/profile.d/rbenv.sh
+
+# Install ruby-build
+RUN mkdir /usr/local/rbenv/plugins
+RUN git clone https://github.com/sstephenson/ruby-build.git /usr/local/rbenv/plugins/ruby-build
+
+# Setup rbenv shimming
+ENV RBENV_ROOT=/usr/local/rbenv
+ENV PATH=$RBENV_ROOT/bin:$RBENV_ROOT/shims:$PATH
 
 # Install ruby versions
 RUN rbenv install ${RUBY_VERSION} && rbenv global ${RUBY_VERSION}

--- a/images/node-rbenv/node-24-slim/ruby-3/Dockerfile
+++ b/images/node-rbenv/node-24-slim/ruby-3/Dockerfile
@@ -9,12 +9,48 @@ ARG RUBY_VERSION=3.4.5
 
 # ====================================================== PRODUCT =======================================================
 
-FROM kula/node-rbenv:${NODE_VERSION}-slim
+FROM node:${NODE_VERSION}-slim
 ARG RUBY_VERSION
 
 # Metadata
 LABEL maintainer="kula app GmbH <opensource@kula.app>"
 LABEL description="Container with rbenv and node 24 slim with ruby 3"
+
+# Update dependencies
+RUN apt-get update -qq >/dev/null && apt-get upgrade -y --no-install-recommends
+RUN apt-get install -y \
+  autoconf \
+  bison \
+  build-essential \
+  curl \
+  git \
+  libdb-dev \
+  libffi-dev \
+  libgdbm-dev \
+  libgdbm6 \
+  libncurses5-dev \
+  libreadline6-dev \
+  libssl-dev \
+  libyaml-dev \
+  uuid-dev \
+  zlib1g-dev && \
+  rm -rf /var/lib/apt/lists/*
+
+# Install rbenv
+RUN git clone https://github.com/sstephenson/rbenv.git /usr/local/rbenv
+RUN echo '# rbenv setup' >/etc/profile.d/rbenv.sh
+RUN echo 'export RBENV_ROOT=/usr/local/rbenv' >>/etc/profile.d/rbenv.sh
+RUN echo 'export PATH="$RBENV_ROOT/bin:$PATH"' >>/etc/profile.d/rbenv.sh
+RUN echo 'eval "$(rbenv init -)"' >>/etc/profile.d/rbenv.sh
+RUN chmod +x /etc/profile.d/rbenv.sh
+
+# Install ruby-build
+RUN mkdir /usr/local/rbenv/plugins
+RUN git clone https://github.com/sstephenson/ruby-build.git /usr/local/rbenv/plugins/ruby-build
+
+# Setup rbenv shimming
+ENV RBENV_ROOT=/usr/local/rbenv
+ENV PATH=$RBENV_ROOT/bin:$RBENV_ROOT/shims:$PATH
 
 # Install ruby versions
 RUN rbenv install ${RUBY_VERSION} && rbenv global ${RUBY_VERSION}

--- a/images/node-rbenv/node-24/ruby-3/Dockerfile
+++ b/images/node-rbenv/node-24/ruby-3/Dockerfile
@@ -9,12 +9,48 @@ ARG RUBY_VERSION=3.4.5
 
 # ====================================================== PRODUCT =======================================================
 
-FROM kula/node-rbenv:${NODE_VERSION}
+FROM node:${NODE_VERSION}
 ARG RUBY_VERSION
 
 # Metadata
 LABEL maintainer="kula app GmbH <opensource@kula.app>"
 LABEL description="Container with rbenv and node 24 with ruby 3"
+
+# Update dependencies
+RUN apt-get update -qq >/dev/null && apt-get upgrade -y --no-install-recommends
+RUN apt-get install -y \
+  autoconf \
+  bison \
+  build-essential \
+  curl \
+  git \
+  libdb-dev \
+  libffi-dev \
+  libgdbm-dev \
+  libgdbm6 \
+  libncurses5-dev \
+  libreadline6-dev \
+  libssl-dev \
+  libyaml-dev \
+  uuid-dev \
+  zlib1g-dev && \
+  rm -rf /var/lib/apt/lists/*
+
+# Install rbenv
+RUN git clone https://github.com/sstephenson/rbenv.git /usr/local/rbenv
+RUN echo '# rbenv setup' >/etc/profile.d/rbenv.sh
+RUN echo 'export RBENV_ROOT=/usr/local/rbenv' >>/etc/profile.d/rbenv.sh
+RUN echo 'export PATH="$RBENV_ROOT/bin:$PATH"' >>/etc/profile.d/rbenv.sh
+RUN echo 'eval "$(rbenv init -)"' >>/etc/profile.d/rbenv.sh
+RUN chmod +x /etc/profile.d/rbenv.sh
+
+# Install ruby-build
+RUN mkdir /usr/local/rbenv/plugins
+RUN git clone https://github.com/sstephenson/ruby-build.git /usr/local/rbenv/plugins/ruby-build
+
+# Setup rbenv shimming
+ENV RBENV_ROOT=/usr/local/rbenv
+ENV PATH=$RBENV_ROOT/bin:$RBENV_ROOT/shims:$PATH
 
 # Install ruby versions
 RUN rbenv install ${RUBY_VERSION} && rbenv global ${RUBY_VERSION}


### PR DESCRIPTION
Fixes the problem where node-rbenv images are not yet for new versions, but the ones with ruby pre-installed rely on it.