### PR TITLE
fix(renovate): add customManager regex for Dockerfile ARG annotations

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,16 @@
       "schedule:daily"
     ]
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+) versioning=(?<versioning>[^\\s]+)\\nARG \\w+=(?<currentValue>.+)"
+      ],
+      "extractVersionTemplate": "^(v|go)?(?<version>[\\d][\\d.]+.*)$"
+    }
+  ],
   "packageRules": [
     {
       "automerge": false,


### PR DESCRIPTION
## Summary
- Adds a `customManagers` regex entry to `renovate.json` that matches all `# renovate:` annotations followed by `ARG` assignments in Dockerfiles
- Uses `extractVersionTemplate` (`^(v|go)?(?<version>[\d][\d.]+.*)$`) to strip common tag prefixes (`v`, `go`) and filter out sub-package tags (e.g. pulumi's `sdk/go/v3.x.x`)
- Fixes Renovate not proposing updates for `pulumi/pulumi` due to its non-standard release tag structure

## Test plan
- [ ] Verify Renovate dry-run picks up `pulumi/pulumi` as a dependency
- [ ] Confirm existing dependencies (golang, kubernetes, node, ruby, dprint, alpine) are still detected