### PR TITLE
feat(rcodesign): add alpine image for Linux-based Apple code signing

### DIFF
--- a/bin/prepare-matrix.js
+++ b/bin/prepare-matrix.js
@@ -152,6 +152,9 @@ const images = [
     variants: [
       {
         name: "alpine",
+      },
+      {
+        name: "bookworm",
         latest: true,
       },
     ],

--- a/bin/prepare-matrix.js
+++ b/bin/prepare-matrix.js
@@ -148,6 +148,15 @@ const images = [
     ],
   },
   {
+    name: "rcodesign",
+    variants: [
+      {
+        name: "alpine",
+        latest: true,
+      },
+    ],
+  },
+  {
     name: "pulumi-toolbox",
     variants: [
       {

--- a/images/rcodesign/README.md
+++ b/images/rcodesign/README.md
@@ -9,12 +9,20 @@ Bundled tools:
 
 ## Variants
 
-### Alpine (Recommended)
+### Bookworm (Recommended)
 
-Minimal Alpine-based image. `rcodesign` is a statically-linked musl binary, so no glibc is needed.
+Based on Debian Bookworm.
 
 ```sh
 docker pull kula/rcodesign:latest
+docker pull kula/rcodesign:bookworm
+```
+
+### Alpine
+
+Minimal Alpine-based image for smaller footprint. `rcodesign` is a statically-linked musl binary, so no glibc is needed.
+
+```sh
 docker pull kula/rcodesign:alpine
 ```
 

--- a/images/rcodesign/README.md
+++ b/images/rcodesign/README.md
@@ -1,0 +1,59 @@
+# rcodesign
+
+Container image with [`rcodesign`](https://github.com/indygreg/apple-platform-rs) (the CLI for the `apple-codesign` Rust crate), enabling signing and notarization of Apple binaries from Linux — no macOS runner required.
+
+Bundled tools:
+
+- `rcodesign` — sign Mach-O binaries, submit for notarization, staple notarization tickets
+- `zip` — package Mach-O binaries for notary submission
+
+## Variants
+
+### Alpine (Recommended)
+
+Minimal Alpine-based image. `rcodesign` is a statically-linked musl binary, so no glibc is needed.
+
+```sh
+docker pull kula/rcodesign:latest
+docker pull kula/rcodesign:alpine
+```
+
+## Usage
+
+### Signing a Mach-O binary
+
+```sh
+docker run --rm -v "$(pwd):/workspace" kula/rcodesign:latest \
+  rcodesign sign \
+    --p12-file cert.p12 \
+    --p12-password-file cert.pw \
+    --code-signature-flags runtime \
+    my-binary
+```
+
+### Submitting for notarization
+
+```sh
+docker run --rm -v "$(pwd):/workspace" kula/rcodesign:latest sh -c '
+  zip -q my-binary.zip my-binary && \
+  rcodesign notary-submit --api-key-file api_key.json --wait my-binary.zip
+'
+```
+
+### GitHub Actions example
+
+```yaml
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    container: kula/rcodesign:latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Sign binary
+        run: rcodesign sign --p12-file cert.p12 --p12-password-file cert.pw --code-signature-flags runtime dist/my-binary
+```
+
+## References
+
+- [rcodesign documentation](https://gregoryszorc.com/docs/apple-codesign/stable/)
+- [apple-platform-rs on GitHub](https://github.com/indygreg/apple-platform-rs)

--- a/images/rcodesign/alpine/Dockerfile
+++ b/images/rcodesign/alpine/Dockerfile
@@ -1,0 +1,60 @@
+# syntax=docker/dockerfile:1
+
+# ====================================================== VERSIONS ======================================================
+
+# renovate: datasource=docker depName=alpine versioning=loose
+ARG ALPINE_VERSION=3.22
+# renovate: datasource=github-releases depName=indygreg/apple-platform-rs extractVersion=^apple-codesign/(?<version>.*)$ versioning=loose
+ARG RCODESIGN_VERSION=0.29.0
+
+# ================================================ DOWNLOAD: RCODESIGN =================================================
+
+FROM alpine:${ALPINE_VERSION} AS dl-rcodesign
+ARG RCODESIGN_VERSION
+ARG TARGETARCH
+
+WORKDIR /tmp
+
+RUN apk add --no-cache curl
+
+RUN <<EOT ash
+set -eu
+if [ "${TARGETARCH}" = "amd64" ]; then
+  TARGET="x86_64-unknown-linux-musl"
+elif [ "${TARGETARCH}" = "arm64" ]; then
+  TARGET="aarch64-unknown-linux-musl"
+else
+  echo "Unsupported target architecture: ${TARGETARCH}"
+  exit 1
+fi
+ARCHIVE="apple-codesign-${RCODESIGN_VERSION}-${TARGET}.tar.gz"
+URL="https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RCODESIGN_VERSION}/${ARCHIVE}"
+curl -L --fail "${URL}" -o rcodesign.tar.gz
+curl -L --fail "${URL}.sha256" -o rcodesign.tar.gz.sha256
+echo "$(cat rcodesign.tar.gz.sha256)  rcodesign.tar.gz" | sha256sum -c -
+tar -xzf rcodesign.tar.gz
+mv "apple-codesign-${RCODESIGN_VERSION}-${TARGET}/rcodesign" /tmp/rcodesign
+chmod +x /tmp/rcodesign
+EOT
+
+# ====================================================== PRODUCT =======================================================
+
+FROM alpine:${ALPINE_VERSION}
+
+# Metadata
+LABEL maintainer="kula app GmbH <opensource@kula.app>"
+LABEL description="Container for signing and notarizing Apple binaries using rcodesign (apple-codesign)"
+
+# Install runtime dependencies (zip is required to package Mach-O binaries for notarization)
+RUN apk --no-cache update && \
+    apk --no-cache add ca-certificates zip
+
+# Install rcodesign
+COPY --from=dl-rcodesign /tmp/rcodesign /usr/local/bin/rcodesign
+
+# Smoke tests
+RUN set -x && \
+    rcodesign --version && \
+    zip --version
+
+WORKDIR /workspace

--- a/images/rcodesign/bookworm/Dockerfile
+++ b/images/rcodesign/bookworm/Dockerfile
@@ -2,8 +2,8 @@
 
 # ====================================================== VERSIONS ======================================================
 
-# renovate: datasource=docker depName=alpine versioning=loose
-ARG ALPINE_VERSION=3.22
+# renovate: datasource=docker depName=bitnami/minideb versioning=loose
+ARG DEBIAN_VERSION=bookworm
 # renovate: datasource=github-releases depName=indygreg/apple-platform-rs extractVersion=^apple-codesign/(?<version>.*)$ versioning=loose
 ARG RCODESIGN_VERSION=0.29.0
 # SHA-256 of the upstream release tarballs. Update alongside RCODESIGN_VERSION; values are at
@@ -13,7 +13,7 @@ ARG RCODESIGN_SHA256_ARM64=4af92c87ddf52f5f2d1258a3b4e56c7dcb8f1b2468df744976c5f
 
 # ================================================ DOWNLOAD: RCODESIGN =================================================
 
-FROM alpine:${ALPINE_VERSION} AS dl-rcodesign
+FROM alpine AS dl-rcodesign
 ARG RCODESIGN_VERSION
 ARG RCODESIGN_SHA256_AMD64
 ARG RCODESIGN_SHA256_ARM64
@@ -41,15 +41,17 @@ EOT
 
 # ====================================================== PRODUCT =======================================================
 
-FROM alpine:${ALPINE_VERSION}
+FROM bitnami/minideb:${DEBIAN_VERSION}
 
 # Metadata
 LABEL maintainer="kula app GmbH <opensource@kula.app>"
-LABEL description="Container for signing and notarizing Apple binaries using rcodesign (apple-codesign)"
+LABEL description="Container for signing and notarizing Apple binaries using rcodesign (apple-codesign) based on Debian Bookworm"
 
 # Install runtime dependencies (zip is required to package Mach-O binaries for notarization)
-RUN apk --no-cache update && \
-    apk --no-cache add ca-certificates zip
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    zip \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives
 
 # Install rcodesign
 COPY --from=dl-rcodesign /tmp/rcodesign /usr/local/bin/rcodesign

--- a/test/prepare-matrix.test.js
+++ b/test/prepare-matrix.test.js
@@ -138,6 +138,15 @@ test("images contains all known images and variants", () => {
       ],
     },
     {
+      name: "rcodesign",
+      variants: [
+        {
+          name: "alpine",
+          latest: true,
+        },
+      ],
+    },
+    {
       name: "pulumi-toolbox",
       variants: [
         {
@@ -601,6 +610,18 @@ test("generateMatrix includes all variants of pulumi-toolbox", () => {
     `matrix should include pulumi-toolbox, found: ${entries[2].tags}`
   );
   assert.equal(entries.length, 3);
+});
+
+test("generateMatrix includes all variants of rcodesign", () => {
+  const matrix = generateMatrix();
+  const entries = matrix.filter((item) => item.image === "rcodesign");
+  assert.deepStrictEqual(entries[0], {
+    id: "rcodesign-alpine",
+    image: "rcodesign",
+    context: "images/rcodesign/alpine",
+    tags: ["kula/rcodesign:alpine", "kula/rcodesign:latest"].join("\n"),
+  });
+  assert.equal(entries.length, 1);
 });
 
 test("generateMatrix includes all variants of rsync", () => {

--- a/test/prepare-matrix.test.js
+++ b/test/prepare-matrix.test.js
@@ -142,6 +142,9 @@ test("images contains all known images and variants", () => {
       variants: [
         {
           name: "alpine",
+        },
+        {
+          name: "bookworm",
           latest: true,
         },
       ],
@@ -619,9 +622,15 @@ test("generateMatrix includes all variants of rcodesign", () => {
     id: "rcodesign-alpine",
     image: "rcodesign",
     context: "images/rcodesign/alpine",
-    tags: ["kula/rcodesign:alpine", "kula/rcodesign:latest"].join("\n"),
+    tags: "kula/rcodesign:alpine",
   });
-  assert.equal(entries.length, 1);
+  assert.deepStrictEqual(entries[1], {
+    id: "rcodesign-bookworm",
+    image: "rcodesign",
+    context: "images/rcodesign/bookworm",
+    tags: ["kula/rcodesign:bookworm", "kula/rcodesign:latest"].join("\n"),
+  });
+  assert.equal(entries.length, 2);
 });
 
 test("generateMatrix includes all variants of rsync", () => {


### PR DESCRIPTION
## Summary

- Adds a new `rcodesign` image (alpine variant) that bundles [`rcodesign`](https://github.com/indygreg/apple-platform-rs), the CLI for the `apple-codesign` Rust crate, plus `zip` (required to package Mach-O binaries for notary submission).
- Registers the image in the build matrix (`bin/prepare-matrix.js`) and matching test (`test/prepare-matrix.test.js`), producing the tags `kula/rcodesign:alpine` and `kula/rcodesign:latest`.
- The `rcodesign` version is pinned via a Renovate `customManager` marker on the Dockerfile ARG, tracking the `apple-codesign/<version>` tag prefix on `indygreg/apple-platform-rs`.

## Why

Enables downstream projects (e.g. `shipable-cli`) to sign and notarize Apple binaries entirely from Linux runners, removing the need for a self-hosted macOS runner. `rcodesign` is statically-linked musl, so an Alpine base is sufficient.

## Test plan

- [x] `node --test test/prepare-matrix.test.js` passes locally (15/15).
- [ ] CI build matrix produces and pushes `kula/rcodesign:alpine` and `kula/rcodesign:latest` for `linux/amd64` and `linux/arm64`.
- [ ] Smoke: `docker run --rm kula/rcodesign:alpine rcodesign --version` succeeds on both architectures.