### PR TITLE
feat(base): Introduce kula/base images for alpine, bookworm, trixie

### DIFF
--- a/bin/prepare-matrix.js
+++ b/bin/prepare-matrix.js
@@ -33,6 +33,21 @@ const images = [
     ],
   },
   {
+    name: "base",
+    variants: [
+      {
+        name: "alpine",
+      },
+      {
+        name: "bookworm",
+        latest: true,
+      },
+      {
+        name: "trixie",
+      },
+    ],
+  },
+  {
     name: "curl",
     variants: [
       {

--- a/images/base/alpine/Dockerfile
+++ b/images/base/alpine/Dockerfile
@@ -8,6 +8,7 @@ ARG ALPINE_VERSION=3.22
 # ====================================================== PRODUCT =======================================================
 
 FROM alpine:${ALPINE_VERSION}
+ARG ALPINE_VERSION
 
 # Metadata
 LABEL org.opencontainers.image.authors="kula app GmbH <opensource@kula.app>"

--- a/images/base/alpine/Dockerfile
+++ b/images/base/alpine/Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1
+
+# ====================================================== VERSIONS ======================================================
+
+# renovate: datasource=docker depName=alpine versioning=loose
+ARG ALPINE_VERSION=3.22
+
+# ====================================================== PRODUCT =======================================================
+
+FROM alpine:${ALPINE_VERSION}
+
+# Metadata
+LABEL org.opencontainers.image.authors="kula app GmbH <opensource@kula.app>"
+LABEL org.opencontainers.image.vendor="kula app GmbH"
+LABEL org.opencontainers.image.url="https://github.com/kula-app/containers"
+LABEL org.opencontainers.image.source="https://github.com/kula-app/containers"
+LABEL org.opencontainers.image.documentation="https://github.com/kula-app/containers"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.title="kula base (alpine)"
+LABEL org.opencontainers.image.description="Minimal kula-owned base image for alpine"
+LABEL org.opencontainers.image.base.name="alpine:${ALPINE_VERSION}"
+LABEL maintainer="kula app GmbH <opensource@kula.app>"
+LABEL description="Minimal kula-owned base image for alpine"
+
+ENV LANG=C.UTF-8
+
+# Install dependencies
+RUN apk --no-cache update && \
+    apk --no-cache add ca-certificates tzdata tini
+
+# Smoke tests
+RUN set -x && \
+    cat /etc/os-release && \
+    tini --version

--- a/images/base/bookworm/Dockerfile
+++ b/images/base/bookworm/Dockerfile
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1
+
+# ====================================================== VERSIONS ======================================================
+
+# renovate: datasource=docker depName=debian versioning=loose
+ARG DEBIAN_VERSION=bookworm-slim
+
+# ====================================================== PRODUCT =======================================================
+
+FROM debian:${DEBIAN_VERSION}
+
+# Metadata
+LABEL org.opencontainers.image.authors="kula app GmbH <opensource@kula.app>"
+LABEL org.opencontainers.image.vendor="kula app GmbH"
+LABEL org.opencontainers.image.url="https://github.com/kula-app/containers"
+LABEL org.opencontainers.image.source="https://github.com/kula-app/containers"
+LABEL org.opencontainers.image.documentation="https://github.com/kula-app/containers"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.title="kula base (bookworm)"
+LABEL org.opencontainers.image.description="Minimal kula-owned base image for bookworm"
+LABEL org.opencontainers.image.base.name="debian:${DEBIAN_VERSION}"
+LABEL maintainer="kula app GmbH <opensource@kula.app>"
+LABEL description="Minimal kula-owned base image for bookworm"
+
+ENV LANG=C.UTF-8
+
+# Install dependencies
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    tzdata \
+    tini \
+    # Cleanup
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives
+
+# Smoke tests
+RUN set -x && \
+    cat /etc/os-release && \
+    tini --version

--- a/images/base/bookworm/Dockerfile
+++ b/images/base/bookworm/Dockerfile
@@ -8,6 +8,7 @@ ARG DEBIAN_VERSION=bookworm-slim
 # ====================================================== PRODUCT =======================================================
 
 FROM debian:${DEBIAN_VERSION}
+ARG DEBIAN_VERSION
 
 # Metadata
 LABEL org.opencontainers.image.authors="kula app GmbH <opensource@kula.app>"

--- a/images/base/trixie/Dockerfile
+++ b/images/base/trixie/Dockerfile
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1
+
+# ====================================================== VERSIONS ======================================================
+
+# renovate: datasource=docker depName=debian versioning=loose
+ARG DEBIAN_VERSION=trixie-slim
+
+# ====================================================== PRODUCT =======================================================
+
+FROM debian:${DEBIAN_VERSION}
+
+# Metadata
+LABEL org.opencontainers.image.authors="kula app GmbH <opensource@kula.app>"
+LABEL org.opencontainers.image.vendor="kula app GmbH"
+LABEL org.opencontainers.image.url="https://github.com/kula-app/containers"
+LABEL org.opencontainers.image.source="https://github.com/kula-app/containers"
+LABEL org.opencontainers.image.documentation="https://github.com/kula-app/containers"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.title="kula base (trixie)"
+LABEL org.opencontainers.image.description="Minimal kula-owned base image for trixie"
+LABEL org.opencontainers.image.base.name="debian:${DEBIAN_VERSION}"
+LABEL maintainer="kula app GmbH <opensource@kula.app>"
+LABEL description="Minimal kula-owned base image for trixie"
+
+ENV LANG=C.UTF-8
+
+# Install dependencies
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    tzdata \
+    tini \
+    # Cleanup
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives
+
+# Smoke tests
+RUN set -x && \
+    cat /etc/os-release && \
+    tini --version

--- a/images/base/trixie/Dockerfile
+++ b/images/base/trixie/Dockerfile
@@ -8,6 +8,7 @@ ARG DEBIAN_VERSION=trixie-slim
 # ====================================================== PRODUCT =======================================================
 
 FROM debian:${DEBIAN_VERSION}
+ARG DEBIAN_VERSION
 
 # Metadata
 LABEL org.opencontainers.image.authors="kula app GmbH <opensource@kula.app>"

--- a/test/prepare-matrix.test.js
+++ b/test/prepare-matrix.test.js
@@ -23,6 +23,21 @@ test("images contains all known images and variants", () => {
       ],
     },
     {
+      name: "base",
+      variants: [
+        {
+          name: "alpine",
+        },
+        {
+          name: "bookworm",
+          latest: true,
+        },
+        {
+          name: "trixie",
+        },
+      ],
+    },
+    {
       name: "curl",
       variants: [
         {
@@ -233,6 +248,30 @@ test("generateMatrix includes all variants of atlas-app-services-cli", () => {
     tags: "kula/atlas-app-services-cli:latest",
   });
   assert.equal(entries.length, 1);
+});
+
+test("generateMatrix includes all variants of base", () => {
+  const matrix = generateMatrix();
+  const entries = matrix.filter((item) => item.image === "base");
+  assert.deepStrictEqual(entries[0], {
+    id: "base-alpine",
+    image: "base",
+    context: "images/base/alpine",
+    tags: "kula/base:alpine",
+  });
+  assert.deepStrictEqual(entries[1], {
+    id: "base-bookworm",
+    image: "base",
+    context: "images/base/bookworm",
+    tags: ["kula/base:bookworm", "kula/base:latest"].join("\n"),
+  });
+  assert.deepStrictEqual(entries[2], {
+    id: "base-trixie",
+    image: "base",
+    context: "images/base/trixie",
+    tags: "kula/base:trixie",
+  });
+  assert.equal(entries.length, 3);
 });
 
 test("generateMatrix includes all variants of curl", () => {


### PR DESCRIPTION
Add three minimal base images built directly on Docker Official images (`alpine:3.22`, `debian:bookworm-slim`, `debian:trixie-slim`) so that downstream images can stop depending on `bitnami/minideb` as a production root.

Bitnami has been removing images from Docker Hub, which is a concrete supply-chain risk for our build pipeline. Owning one more layer of the chain via `kula/base` lets us anchor on Docker Official upstreams whose policy we control.

Each base image stays intentionally thin:
- `ca-certificates`, `tzdata`, `tini`
- `ENV LANG=C.UTF-8`
- Full OCI-spec LABEL set (`authors`, `vendor`, `url`, `source`, `documentation`, `licenses`, `title`, `description`, `base.name`) so downstream images inherit shared metadata and only override what differs (`title`, `description`, `base.name`).
- Legacy `maintainer` + `description` labels retained for back-compat with anything that greps them today.

This first PR introduces the base images alone — no downstream Dockerfile is migrated yet. Once these tags are published, follow-up PRs will:
1. Swap the `bitnami/minideb` and `alpine:*` FROM lines on existing images to `kula/base:*` and apply the override-only label block.
2. Add the missing `trixie` (and `bookworm` where missing) variants, plus `pulumi-toolbox/trixie-rbenv`.
3. Drop `lftp/bullseye` and remove `itms-transporter` entirely.
4. Split `build-images.yml` into a base-first / rest-second job so downstream builds always see fresh `kula/base:*` tags.

## Notes for review
- Renovate annotation `# renovate: datasource=docker depName=alpine|debian versioning=loose` matches the existing convention used by other Dockerfiles in this repo.
- New matrix entry sits alphabetically between `atlas-app-services-cli` and `curl`. `bookworm` carries the `:latest` tag.
- Test coverage mirrors the existing per-image test pattern; `make test` passes (16/16).