### PR TITLE
build(golang-toolbox): Add analyzer tools and trixie variant

### DIFF
--- a/bin/prepare-matrix.js
+++ b/bin/prepare-matrix.js
@@ -66,6 +66,9 @@ const images = [
         name: "bookworm",
         latest: true,
       },
+      {
+        name: "trixie",
+      },
     ],
   },
   {

--- a/images/golang-toolbox/README.md
+++ b/images/golang-toolbox/README.md
@@ -13,8 +13,18 @@ The following CLI tools are included in the Go Toolbox:
 - `pkg-config` - Package configuration tool (bookworm variant only)
 - `unzip` - Archive extraction utility
 - `dprint` - Code formatter
+- `staticcheck` - Static analysis for Go
+- `govulncheck` - Go vulnerability scanner
 
 ## Variants
+
+### Trixie
+
+Based on Debian Trixie with bash and full build tools.
+
+```sh
+docker pull kula/golang-toolbox:trixie
+```
 
 ### Bookworm (Recommended)
 

--- a/images/golang-toolbox/alpine/Dockerfile
+++ b/images/golang-toolbox/alpine/Dockerfile
@@ -5,9 +5,13 @@
 # renovate: datasource=docker depName=alpine versioning=loose
 ARG ALPINE_VERSION=3.23
 # renovate: datasource=github-releases depName=golang/go versioning=loose
-ARG GO_VERSION=1.26.0
+ARG GO_VERSION=1.26.3
 # renovate: datasource=github-releases depName=dprint/dprint versioning=loose
-ARG DPRINT_VERSION=0.52.0
+ARG DPRINT_VERSION=0.54.0
+# renovate: datasource=go depName=honnef.co/go/tools versioning=semver
+ARG STATICCHECK_VERSION=0.7.0
+# renovate: datasource=go depName=golang.org/x/vuln versioning=semver
+ARG GOVULNCHECK_VERSION=1.3.0
 
 # ==================================================== DOWNLOAD: GO ====================================================
 
@@ -55,7 +59,9 @@ EOT
 
 # ====================================================== PRODUCT =======================================================
 
-FROM alpine:${ALPINE_VERSION}
+FROM kula/base:alpine
+ARG STATICCHECK_VERSION
+ARG GOVULNCHECK_VERSION
 
 # Metadata
 LABEL maintainer="kula app GmbH <opensource@kula.app>"
@@ -94,13 +100,19 @@ ENV PATH="${GOPATH}/bin:${PATH}"
 RUN mkdir -p "${GOPATH}/src" "${GOPATH}/bin" && \
     chmod -R 777 "${GOPATH}"
 
+# Install Go analysis tools
+RUN go install "honnef.co/go/tools/cmd/staticcheck@v${STATICCHECK_VERSION}" && \
+    go install "golang.org/x/vuln/cmd/govulncheck@v${GOVULNCHECK_VERSION}"
+
 # Smoke tests
 RUN set -x && \
     go version && \
     make --version && \
     gcc --version && \
     git --version && \
-    dprint --version
+    dprint --version && \
+    staticcheck --version && \
+    govulncheck --version
 
 # Set working directory
 WORKDIR /workspace

--- a/images/golang-toolbox/bookworm/Dockerfile
+++ b/images/golang-toolbox/bookworm/Dockerfile
@@ -44,9 +44,9 @@ RUN apk add --no-cache curl unzip
 
 RUN <<EOT ash
 if [ "${TARGETARCH}" = "amd64" ]; then
-  curl -L --fail "https://github.com/dprint/dprint/releases/download/${DPRINT_VERSION}/dprint-x86_64-unknown-linux-gnu.zip" -o dprint.zip
+  curl -L --fail "https://github.com/dprint/dprint/releases/download/${DPRINT_VERSION}/dprint-x86_64-unknown-linux-musl.zip" -o dprint.zip
 elif [ "${TARGETARCH}" = "arm64" ]; then
-  curl -L --fail "https://github.com/dprint/dprint/releases/download/${DPRINT_VERSION}/dprint-aarch64-unknown-linux-gnu.zip" -o dprint.zip
+  curl -L --fail "https://github.com/dprint/dprint/releases/download/${DPRINT_VERSION}/dprint-aarch64-unknown-linux-musl.zip" -o dprint.zip
 else
   echo "Unsupported target architecture: ${TARGETARCH}"
   exit 1

--- a/images/golang-toolbox/trixie/Dockerfile
+++ b/images/golang-toolbox/trixie/Dockerfile
@@ -44,9 +44,9 @@ RUN apk add --no-cache curl unzip
 
 RUN <<EOT ash
 if [ "${TARGETARCH}" = "amd64" ]; then
-  curl -L --fail "https://github.com/dprint/dprint/releases/download/${DPRINT_VERSION}/dprint-x86_64-unknown-linux-gnu.zip" -o dprint.zip
+  curl -L --fail "https://github.com/dprint/dprint/releases/download/${DPRINT_VERSION}/dprint-x86_64-unknown-linux-musl.zip" -o dprint.zip
 elif [ "${TARGETARCH}" = "arm64" ]; then
-  curl -L --fail "https://github.com/dprint/dprint/releases/download/${DPRINT_VERSION}/dprint-aarch64-unknown-linux-gnu.zip" -o dprint.zip
+  curl -L --fail "https://github.com/dprint/dprint/releases/download/${DPRINT_VERSION}/dprint-aarch64-unknown-linux-musl.zip" -o dprint.zip
 else
   echo "Unsupported target architecture: ${TARGETARCH}"
   exit 1

--- a/images/golang-toolbox/trixie/Dockerfile
+++ b/images/golang-toolbox/trixie/Dockerfile
@@ -57,13 +57,13 @@ EOT
 
 # ====================================================== PRODUCT =======================================================
 
-FROM kula/base:bookworm
+FROM kula/base:trixie
 ARG STATICCHECK_VERSION
 ARG GOVULNCHECK_VERSION
 
 # Metadata
 LABEL maintainer="kula app GmbH <opensource@kula.app>"
-LABEL description="Container with Go toolchain and essential build tools based on Debian Bookworm"
+LABEL description="Container with Go toolchain and essential build tools based on Debian Trixie"
 
 # Install build dependencies and tools
 RUN apt-get update -y && apt-get install -y --no-install-recommends \

--- a/test/prepare-matrix.test.js
+++ b/test/prepare-matrix.test.js
@@ -56,6 +56,9 @@ test("images contains all known images and variants", () => {
           name: "bookworm",
           latest: true,
         },
+        {
+          name: "trixie",
+        },
       ],
     },
     {
@@ -313,7 +316,17 @@ test("generateMatrix includes all variants of golang-toolbox", () => {
     },
     `matrix should include golang-toolbox, found: ${entries[1].tags}`
   );
-  assert.equal(entries.length, 2);
+  assert.deepStrictEqual(
+    entries[2],
+    {
+      id: "golang-toolbox-trixie",
+      image: "golang-toolbox",
+      context: "images/golang-toolbox/trixie",
+      tags: "kula/golang-toolbox:trixie",
+    },
+    `matrix should include golang-toolbox, found: ${entries[2].tags}`
+  );
+  assert.equal(entries.length, 3);
 });
 
 test("generateMatrix includes all variants of itms-transporter", () => {


### PR DESCRIPTION
Update the Go toolbox images for current Go CI usage.

This adds a Debian Trixie variant, moves the existing Debian and Alpine
variants onto the kula/base images, updates Go and dprint, and preinstalls the
Go analyzer binaries used by CI:

- staticcheck
- govulncheck

The matrix generator and tests now include the trixie variant.
